### PR TITLE
Spanish Translation (UTF-8) - Tested on v0.5.0 (b39)

### DIFF
--- a/res/copy/lang/Spanish.ini
+++ b/res/copy/lang/Spanish.ini
@@ -1,0 +1,2183 @@
+[Info]
+Author = danielcshn
+AuthorMail = 67213069+danielcshn@users.noreply.github.com
+Date = 20.01.26
+Version = 16
+Code = ES
+
+[Strings]
+//Lang_MainMenu
+0 = Menú Principal
+
+//Lang_NewMap
+1 = Nuevo documento
+
+//Lang_Open
+2 = Abrir
+
+//Lang_Options
+3 = Opciones
+
+ //Lang_Authors
+4 = Autores
+
+//Lang_Exit
+5 = Salir
+
+//Lang_About
+6 = Sobre
+
+//Lang_GamePath
+7 = Ruta del juego
+
+//Lang_Save
+9 = Guardar
+
+//Lang_Back
+10 = Atrás
+
+//Lang_Browse
+11 = Navegar
+
+//Lang_LastUsed
+12 = Usado por última vez
+
+//Lang_Name
+13 = Nombre:
+
+//Lang_Author
+14 = Autor:
+
+//Lang_Date
+15 = Fecha:
+
+//Lang_Visibility
+16 = Visibilidad
+
+//Lang_AlphaOverlapping
+17 = Hacer que los planos superpuestos sean transparentes
+
+//Lang_ScrollScrollsVerticaly
+18 = Desplazamiento del mouse se realiza verticalmente.
+
+//Lang_ScrollScrollsHorizontaly
+19 = Desplazamiento del mouse se realiza en sentido horizontal.
+
+//Lang_ScrollZooms
+20 = Desplazamiento del mouse acerca y aleja la imagen.
+
+//Lang_ObjectsOn
+21 = Objetos activados para el plano ~y~%s~w~.
+
+//Lang_ObjectsOff
+22 = Objetos desactivados para el plano ~y~%s~w~.
+
+//Lang_GridOn
+23 = Grilla activada para el plano ~y~%s~w~.
+
+//Lang_GridOff
+24 = Grilla desactivada para el plano ~y~%s~w~.
+
+//Lang_BoundaryOn
+25 = Límite activado para el plano ~y~%s~w~.
+
+//Lang_BoundaryOff
+26 = Límite desactivado para el plano ~y~%s~w~.
+
+//Lang_InfoBar
+27 = Zoom: %.2f Mouse: %d x %d Tile: %dx%d FPS: %d
+
+//Lang_OK
+28 = Ok
+
+//Lang_Yes
+29 = Si
+
+//Lang_No
+30 = No
+
+//Lang_Cancel
+31 = Cancelar
+
+//Lang_Opening
+32 = Abrir
+
+//Lang_ErrorOpeningFile
+33 = Se produjo un error al cargar el archivo especificado
+
+//Lang_ErrorInfo
+34 = Información de error
+
+//Lang_Number
+35 = Número
+
+//Lang_Desc
+36 = Descripción
+
+//Lang_ErrorOpening
+37 = Error de apertura
+
+//Lang_FailLocatingREZ
+38 = No se puede localizar REZ predeterminado
+
+//Lang_MapProperties
+39 = Propiedades del mapa
+
+//Lang_PathREZ
+40 = Ruta REZ:
+
+//Lang_PathTiles
+41 = Ruta Tiles:
+
+//Lang_PathPAL
+42 = Ruta Paleta:
+
+//Lang_Compress
+43 = Compresión
+
+//Lang_ZCoords
+44 = Utilice coordenadas Z
+
+//Lang_Exe
+45 = Ejecutable:
+
+//Lang_EnableConsole
+46 = Habilitar consola
+
+//Lang_Language
+47 = Idioma
+
+//Lang_Properties
+48 = Propiedades
+
+//Lang_Delete
+49 = Borrar
+
+//Lang_Move
+50 = Mover
+
+//Lang_ID
+51 = ID
+
+//Lang_Logic
+52 = Lógica
+
+//Lang_Anim
+53 = Animación
+
+//Lang_Graphic
+54 = Gráfico
+
+//Lang_CopyToClipboard
+55 = Exportar como texto
+
+//Lang_Position
+56 = Posición
+
+//Lang_Score
+57 = Puntaje
+
+//Lang_Points
+58 = Puntos
+
+//Lang_Powerup
+59 = Powerup
+
+//Lang_Damage
+60 = Daño
+
+//Lang_Smarts
+61 = Smarts
+
+//Lang_Health
+62 = Salud
+
+//Lang_MinCoord
+63 = Min. coords
+
+//Lang_MaxCoord
+64 = Max. coords
+
+//Lang_SpeedDirs
+65 = Velocidad (dirs.)
+
+//Lang_Tweak
+66 = Ajustar
+
+//Lang_Counter
+67 = Contador
+
+//Lang_Speed
+68 = Velocidad
+
+//Lang_Dimensions
+69 = Dimensiones
+
+//Lang_Direction
+70 = Dirección
+
+//Lang_FacingDirection
+71 = Orientado hacia dir.
+
+//Lang_TimeDelay
+72 = Retardo de tiempo
+
+//Lang_FrameDelay
+73 = Retraso de fotogramas
+
+//Lang_MoveRes
+74 = Mover Res
+
+//Lang_MoveRect
+75 = Mover rect.
+
+//Lang_HitRect
+76 = Golpe rect.
+
+//Lang_AttackRect
+77 = Ataque rect.
+
+//Lang_ClipRect
+78 = Clip rect.
+
+//Lang_UserRect
+79 = User rect.
+
+//Lang_UserValues
+80 = Valores de usuario
+
+//Lang_ObjExported
+81 = El objeto ha sido copiado al portapapeles.
+
+//Lang_ObjExportFailed
+82 = Error al copiar el objeto.
+
+//Lang_Advanced
+83 = Avanzado
+
+//Lang_ObjectProperties
+84 = Propiedades del objeto
+
+//Lang_Sound
+85 = Sonido
+
+//Lang_Treasure
+86 = Tesoro
+
+//Lang_Curse
+87 = Maldición
+
+//Lang_MapShot
+88 = Toma del mapa
+
+//Lang_SaveAs
+89 = Guardar como
+
+//Lang_Scale
+90 = Escala
+
+//Lang_Database
+91 = Base de datos
+
+//Lang_Progress
+92 = Progreso
+
+//Lang_ActualOperation
+93 = Operación real
+
+//Lang_Message
+94 = Mensaje
+
+//Lang_ExitUnsaved
+95 = Se perderán todos los cambios no guardados. ¿Seguro que quieres salir?
+
+//Lang_Border
+96 = Borde
+
+//Lang_Animate
+97 = Animar
+
+//Lang_LoadingMapFile
+98 = Cargando archivo de mapa
+
+//Lang_LoadingResourceFile
+99 = Cargando archivo de recursos
+
+//Lang_LoadingPalette
+100 = Cargando paleta
+
+//Lang_LoadingBrushes
+101 = Cargando pinceles
+
+//Lang_PreparingTexForTiles
+102 = Preparación de texturas para baldosas
+
+//Lang_DrawingTiles
+103 = Dibujando de Tiles
+
+//Lang_DrawingTile
+104 = Dibujando de Tile
+
+//Lang_CreatingSpriteBank
+105 = Creando un banco de sprites
+
+//Lang_CreatingSpriteBankLevel
+106 = Creando un banco de sprites (nivel)
+
+//Lang_CreatingSpriteBankGlob
+107 = Creación de un banco de sprites (global)
+
+//Lang_LoadingQueue
+108 = Cola de carga
+
+//Lang_Ready
+109 = Listo
+
+//Lang_UseSmoothZooming
+110 = Utilice el zoom suave
+
+//Lang_Location
+111 = Posición
+
+//Lang_DrawingFlags
+112 = Dibujando banderas
+
+//Lang_NoDraw
+113 = Sin Dibujar
+
+//Lang_Mirror
+114 = Espejo
+
+//Lang_SelectResourceFromList
+115 = ~l~Seleccione un recurso de la lista de la izquierda.
+
+//Lang_ObjectsDrawingOptions
+116 = Opciones de dibujo de objetos
+
+//Lang_DrawObjWithNoDraw
+117 = Objetos con la bandera NoDraw
+
+//Lang_Treasures
+119 = Tesoros
+
+//Lang_Other
+120 = Otros
+
+//Lang_NoBrushes
+121 = Sin pinceles
+
+//Lang_Plane
+134 = Plano
+
+//Lang_MapShotDimensions
+135 = Dimensiones de la imagen: %dx%d pixels
+
+//Lang_MakingMapshot
+136 = Creando una captura de mapa...
+
+//Lang_Duplicate
+137 = Duplicado
+
+//Lang_Duplicating
+138 = Duplicando
+
+//Lang_CopyXTimes
+139 = Número de copias
+
+//Lang_OffsetX
+140 = Offset X
+
+//Lang_OffsetY
+141 = Offset Y
+
+//Lang_OffsetZ
+142 = Offset Z
+
+//Lang_SourceObjectID
+143 = ID del objeto de origen
+
+//Lang_Game
+144 = Juego
+
+//Lang_GameUnknown
+145 = unknown
+
+//Lang_GameClaw
+8 = Claw
+
+//Lang_GameGruntz
+146 = Gruntz
+
+//Lang_GameGetMedieval
+147 = Obtener Medieval
+
+//Lang_Camera
+148 = Camera
+
+//Lang_SetToCoords
+149 = Establecer en coordenadas.
+
+//Lang_SetToSpawn
+150 = Setear spawn
+
+//Lang_Cut
+151 = Cortar
+
+//Lang_Copy
+152 = Copiar
+
+//Lang_Paste
+153 = Pegar
+
+//Lang_BrushProperties
+154 = Propiedades del pincel
+
+//Lang_UseAsBrush
+155 = Usar como pincel
+
+//Lang_BrushInterval
+156 = Intervalo
+
+//Lang_ExecuteLuaCode
+157 = Ejecutar código Lua
+
+//Lang_ResetLua
+158 = Restablecer intérprete
+
+//Lang_ExecLua
+159 = Ejecutar
+
+//Lang_StartingPlace
+160 = Punto de Spawn
+
+//Lang_LuaError
+161 = Lua error
+
+//Lang_Legend
+162 = Leyenda
+
+//Lang_PropSolid
+163 = Sólido
+
+//Lang_PropGround
+164 = Suelo
+
+//Lang_PropClimb
+165 = Escalar
+
+//Lang_PropDeath
+166 = Muerte
+
+//Lang_Prefix
+167 = Prefix
+
+//Lang_Path
+168 = Ruta
+
+//Lang_AddImageSet
+169 = Agregar conjunto de imágenes
+
+//Lang_EditImageSet
+170 = Editar conjunto de imágenes
+
+//Lang_Add
+171 = Agregar
+
+//Lang_Modify
+172 = Modificar
+
+//Lang_MeasureOptions
+173 = Opciones de medida
+
+//Lang_ShowAbsoluteDistance
+174 = Mostrar distancia absoluta
+
+//Lang_TileProperties
+175 = Tile propiedades
+
+//Lang_Width
+176 = Ancho
+
+//Lang_Height
+177 = Altura
+
+//Lang_AttribSingle
+178 = Simple
+
+//Lang_AttribDouble
+179 = Doble
+
+//Lang_Type
+180 = Tipo
+
+//Lang_Mask
+181 = Máscara
+
+//Lang_AttribInside
+182 = Adentro
+
+//Lang_AttribOutside
+183 = Afuera
+
+//Lang_PropClear
+184 = Limpiar
+
+//Lang_AttribMaskType
+185 = Tipo de dibujo
+
+//Lang_WM
+186 = WapMap
+
+//Lang_TCR
+187 = The Claw Recluse
+
+//Lang_MC
+188 = Centro de la Misión
+
+//Lang_NoNews
+189 = Sin noticias
+
+//Lang_ErrorLoadingNews
+190 = Error de carga
+
+//Lang_LoadingNews
+191 = Cargando noticias...
+
+//Lang_MoreNews
+192 = Más noticias
+
+//Lang_OptionChangesAfterRestart
+193 = Esta opción se utilizará después del próximo inicio.
+
+//Lang_BrushErrorCaption
+194 = Error al cargar el pincel
+
+//Lang_BrushLuaError
+195 = Error al cargar el script de Lua. Detalles:
+
+//Lang_BrushOtherError
+196 = Se produjo un error. Detalles:
+
+//Lang_SearchObject
+197 = Objeto de búsqueda
+
+//Lang_ObjSearchHint
+198 = Introduzca el nombre completo (o parte del mismo) del objeto.
+
+//Lang_NoSearchResults
+199 = No hay resultados de búsqueda.
+
+//Lang_SearchResults
+200 = Resultados de la búsqueda:
+
+//Lang_LocationX
+201 = Posición X
+
+//Lang_LocationY
+202 = Posición Y
+
+//Lang_Invert
+203 = Invertir
+
+//Lang_Flash
+204 = Flash
+
+//Lang_DynamicFlags
+205 = Banderas dinámicas
+
+//Lang_ObjFlag_NoHit
+206 = Sin golpe
+
+//Lang_ObjFlag_AlwaysActive
+207 = Siempre activo
+
+//Lang_ObjFlag_Safe
+208 = Seguro
+
+//Lang_ObjFlag_AutoHitDmg
+209 = Daño por golpe automático
+
+//Lang_AddFlags
+210 = Agregar banderas
+
+//Lang_ObjFlag_Difficult
+211 = Dificultad
+
+//Lang_ObjFlag_EyeCandy
+212 = Eye candy
+
+//Lang_ObjFlag_HighDetail
+213 = Alto nivel de detalle
+
+//Lang_ObjFlag_Multiplayer
+214 = Multijugador
+
+//Lang_ObjFlag_ExtraMemory
+215 = Memoria extra
+
+//Lang_ObjFlag_FastCPU
+216 = CPU Rápido
+
+//Lang_HitTypeFlags
+217 = Puede ser golpeado por
+
+//Lang_ObjFlag_HitType1
+218 = Genérico
+
+//Lang_ObjFlag_HitType2
+219 = Jugador
+
+//Lang_ObjFlag_HitType3
+220 = Enemigo
+
+//Lang_ObjFlag_HitType4
+221 = Powerup
+
+//Lang_ObjFlag_HitType5
+222 = Disparo
+
+//Lang_ObjFlag_HitType6
+223 = PShot
+
+//Lang_ObjFlag_HitType7
+224 = EShot
+
+//Lang_ObjFlag_HitType8
+225 = Especial
+
+//Lang_ObjFlag_HitType9
+226 = Usuario #1
+
+//Lang_ObjFlag_HitType10
+227 = Usuario #2
+
+//Lang_ObjFlag_HitType11
+228 = Usuario #3
+
+//Lang_ObjFlag_HitType12
+229 = Usuario #4
+
+//Lang_TypeFlag
+230 = Tipo de objeto
+
+//Lang_UserFlags
+231 = Usuario flags
+
+//Lang_UserFlag
+232 = Bandera
+
+//Lang_UserValue
+233 = Usuario val.
+
+//Lang_MinX
+234 = Min. X
+
+//Lang_MinY
+235 = Min. Y
+
+//Lang_MaxX
+236 = Max. X
+
+//Lang_MaxY
+237 = Max. Y
+
+//Lang_SpeedX
+238 = Velocidad X
+
+//Lang_SpeedY
+239 = Velocidad Y
+
+//Lang_TweakX
+240 = Ajustar X
+
+//Lang_TweakY
+241 = Ajustar Y
+
+//Lang_MoveResX
+242 = Mover Res X
+
+//Lang_MoveResY
+243 = Mover Res Y
+
+//Lang_AutoUpdate
+244 = Buscar actualizaciones al iniciar la aplicación
+
+//Lang_ActualizeCaption
+245 = Actualización disponible
+
+//Lang_YourVersion
+246 = Versión
+
+//Lang_AvailableVersion
+247 = Versión disponible
+
+//Lang_ActualizeQuestion
+248 = ¡Se lanzó una nueva versión de WapMap!~n~¿Quieres descargarla e instalarla ahora?
+
+//Lang_UpdateSize
+249 = Actualizar tamaño
+
+//Lang_DownloadingUpdate
+250 = Descargando la actualización...
+
+//Lang_PatchRestart
+251 = WapMap necesita reiniciarse ahora para finalizar la actualización.
+
+//Lang_SortingObjects
+252 = Ordenando objetos, por favor espere... (puede tardar un poco)
+
+//Lang_UnableToFindGamePath
+253 = No se puede encontrar la ruta del juego.
+
+//Lang_Error
+254 = Error
+
+//Lang_SpecifyPath
+255 = Especificar ruta
+
+//Lang_SpecifyClawPathDesc
+256 = Por favor especifique el directorio de instalación de Claw.
+
+//Lang_WrongClawPathDesc
+257 = La ruta proporcionada no es válida. El directorio debe contener los archivos ~y~CLAW.EXE~l~ y ~y~CLAW.REZ~l~.
+
+//Lang_SelectedObjects
+259 = Objetos seleccionados
+
+//Lang_ManyObjects
+260 = Muchos
+
+//Lang_LocalyzingResourceFile
+261 = Localización de archivos de recursos
+
+//Lang_DisplayResolution
+262 = Resolución de pantalla
+
+//Lang_DisplayUnsupported
+263 = Resolución no compatible
+
+//Lang_DisplayUnsupportedDesc
+264 = WapMap requiere una resolución de pantalla de al menos 800x600.
+
+//Lang_LoadingSounds
+265 = Sonidos de carga
+
+//Lang_LoadingAnims
+266 = Cargando animaciones
+
+//Lang_SetSpawnPoint
+267 = Establezca el punto de partida aquí
+
+//Lang_BrushOptions
+268 = Opciones de pincel
+
+//Lang_FillColor
+269 = Color de relleno
+
+//Lang_SelectFill
+270 = Seleccionar color de relleno
+
+//Lang_HideFill
+271 = Esconder
+
+//Lang_FillNotice
+272 = Cambio de color tendrá efecto en todos los archivos de un avión!
+
+//Lang_ActualFillColor
+273 = Color Actual
+
+//Lang_SelectedFillCOlor
+274 = Color seleccionado
+
+//Lang_SimExit
+276 = Fin de la simulación
+
+//Lang_SelFromList
+277 = Seleccionar de la lista
+
+//Lang_NewObjectCtx
+278 = Nuevo objeto
+
+//Lang_ModeTile
+279 = Tiles
+
+//Lang_ModeObject
+280 = Objetos
+
+//Lang_SmallScreenWarning_Title
+281 = Resolución no compatible
+
+//Lang_SmallScreenWarning_Message
+282 = La resolución de pantalla de tu dispositivo es inferior al tamaño mínimo admitido. Por lo tanto, podrías experimentar algunos problemas.
+
+//Lang_FilesDragged_Unsupported
+283 = Archivo(s) no compatibles. Eliminarlos no tendrá ningún efecto.
+
+//Lang_FilesDragged_MapsToOpen
+284 = Se abrirán los siguientes documentos de mapas:
+
+//Lang_FilesDragged_AndMore
+285 = ...y %d más.
+
+//Lang_Retry
+286 = Reintentar
+
+//Lang_Skip
+287 = Saltar
+
+//Lang_StartMaximized
+288 = Comience con la ventana maximizada
+
+[Tooltip]
+//Lang_TT_NewDocument
+1 = Nuevo mapa.
+
+//Lang_TT_OpenDocument
+2 = Abrir mapa.
+
+//Lang_TT_Save
+3 = Guardar.
+
+//Lang_TT_SaveAs
+4 = Guardar como.
+
+//Lang_TT_Undo
+5 = Deshacer.
+
+//Lang_TT_Redo
+6 = Rehacer.
+
+//Lang_TT_ActivePlane
+7 = Selecciona el plano en el que trabajarás.
+
+//Lang_TT_Mode
+8 = Cambiar el modo del editor (tiles, objetos, simulación).
+
+//Lang_TT_DisplayOptions
+9 = Opciones de visualización.
+
+//Lang_TT_Camera
+10 = Opciones de cámara.
+
+//Lang_TT_World
+11 = Propiedades del mapa.
+
+//Lang_TT_Planes
+12 = Editar planos.
+
+//Lang_TT_TileAttrib
+13 = Editar atributos de tile.
+
+//Lang_TT_Lua
+14 = Ejecutar código Lua.
+
+//Lang_TT_Mapshot
+15 = Hacer captura de mapa.
+
+//Lang_TT_Statistics
+16 = Estadísticas del mapa.
+
+//Lang_TT_Test
+17 = Ejecuta el juego y prueba el mapa.
+
+//Lang_TT_Database
+18 = Visor de assets del juego.
+
+//Lang_TT_Palette
+19 = Opciones de paleta.
+
+//Lang_TT_RSS
+20 = Lector de noticias.
+
+//Lang_TT_Options
+21 = Opciones del editor.
+
+//Lang_TT_Info
+22 = Acerca de WapMap.
+
+//Lang_TT_Measure
+23 = Measure tool.
+
+//Lang_TT_Pencil
+24 = Herramienta lápiz.
+
+//Lang_TT_Brush
+25 = Herramienta pincel.
+
+//Lang_TT_Fill
+26 = Herramienta de relleno.
+
+//Lang_TT_SearchObject
+27 = Buscar objetos.
+
+//Lang_TT_NewObject
+28 = Crear nuevo objeto.
+
+//Lang_TT_Previous
+29 = Tile previo.
+
+//Lang_TT_Next
+30 = Siguiente tile.
+
+//Lang_TT_TP_Zoom
+31 = Zoom tile.
+
+//Lang_TT_TP_Preview
+32 = Mostrar atributos de tile en el mapa.
+
+//Lang_TT_TP_Pipette
+33 = Pipeta.
+
+//Lang_TT_TP_Apply
+34 = Guardar propiedades de tile.
+
+//Lang_TT_Tile_Rubber
+35 = Herramienta de borrado.
+
+//Lang_TT_Tile_ColorFill
+36 = Relleno de color.
+
+//Lang_TT_Tile_ShowType
+37 = Modo selector (lista/cuadrícula).
+
+//Lang_TT_Tile_ScrollLeft
+38 = Scroll izquierda.
+
+//Lang_TT_Tile_ScrollRight
+39 = Scroll derecha.
+
+//Lang_TT_Brush_Reload
+40 = Recargar pinceles.
+
+//Lang_TT_Brush_Options
+41 = Opciones de pincel.
+
+//Lang_TT_Tile_Pipette
+42 = Pipeta (seleccionar ficha del mapa).
+
+//Lang_TT_Select
+43 = Marquesina rectangular.
+
+//Lang_TT_WriteID
+44 = Edición de texto de Tiles.
+
+//Lang_TT_NewCrumblingPeg
+45 = Crear nuevo crumbling peg.
+
+//Lang_TT_NewBreakPlank
+46 = Crear nuevo break plank.
+
+//Lang_TT_NewTogglePeg
+47 = Crear nuevo toggle peg.
+
+//Lang_TT_NewElevator
+48 = Crear nueva plataforma móvil.
+
+//Lang_TT_NewPathElevator
+49 = Crear una nueva plataforma de seguimiento de ruta.
+
+//Lang_TT_NewSpringBoard
+50 = Crear un nuevo trampolín.
+
+//Lang_TT_NewRope
+51 = Crea una nueva cuerda.
+
+//Lang_TT_NewTreasure
+52 = Crea un nuevo tesoro coleccionable.
+
+//Lang_TT_NewPickup
+53 = Crea un nuevo objeto de recolección de salud o munición.
+
+//Lang_TT_NewPowerup
+54 = Crear nuevo potenciador.
+
+//Lang_TT_NewCurse
+55 = Crea una nueva maldición para el modo multijugador.
+
+//Lang_TT_NewCrate
+56 = Crea una nueva caja frágil.
+
+//Lang_TT_NewStatue
+57 = Crea una nueva estatua rompible.
+
+//Lang_TT_Enemy
+58 = Crea un nuevo enemigo.
+
+//Lang_TT_PowderKeg
+59 = Crea un nuevo polvorín arrojadizo.
+
+//Lang_TT_Cannon
+60 = Crear nuevo cañón automático.
+
+//Lang_TT_FloorSpike
+61 = Crear una nueva punta de piso / hoja de sierra.
+
+//Lang_TT_Shooter
+62 = Crear un nuevo lanzador de proyectiles.
+
+//Lang_TT_CrabNest
+63 = Crear nuevo nido de cangrejo.
+
+//Lang_TT_Laser
+64 = Crear nuevo láser.
+
+//Lang_TT_Stalactite
+65 = Crea una nueva estalactita que cae.
+
+//Lang_TT_Decor
+66 = Crear nuevo elemento de decoración.
+
+//Lang_TT_AddText
+67 = Añadir texto al mapa.
+
+//Lang_TT_Shake
+68 = Crear una nueva zona de activación de vibración de pantalla.
+
+//Lang_TT_Checkpoint
+69 = Crear nuevo punto de control.
+
+//Lang_TT_Warp
+70 = Crear nueva deformación.
+
+//Lang_TT_DialogTrigger
+71 = Crear nuevo disparador de sonido.
+
+//Lang_TT_AmbientSound
+72 = Crea un nuevo sonido ambiental.
+
+//Lang_TT_EndOfLevel
+73 = Crear pieza de mapa (objetivo de nivel).
+
+//Lang_TT_ZoomTool
+74 = Herramienta de zoom.
+
+[WinDatabase]
+Tab_Tilesets = Conjuntos Tile
+Tab_Imagesets = Conjuntos Image
+Tab_Anims = Animaciones
+Tab_Sounds = Sonidos
+
+SelectedImgset = Conjunto de imágenes seleccionado:
+FileCount = Cantidad de archivos:
+SetSize = Tamaño del conjunto:
+SetChecksum = Checksum del conjunto:
+
+FileID = ID del archivo:
+FileChecksum = Checksum del archivo:
+FileSize = Tamaño del archivo:
+FileDim = Dimensiones:
+FileOffset = Desplazamiento:
+FileUserData = Datos de usuario:
+FileIndex = Índice del archivo:
+FileFrame = Índice del frame:
+
+Show_1 = Mostrar todo
+Show_2 = Originales
+Show_3 = Modificados
+
+Border = Dibujar borde
+OffsetBorder = Desplazamiento del borde
+FlipX = Voltear horizontal
+FlipY = Voltear vertical
+
+Flag_1 = Transparencia
+Flag_2 = Memoria de video
+Flag_3 = Memoria del sistema
+Flag_4 = Espejo
+Flag_5 = Invertir
+Flag_6 = Compresión
+Flag_7 = Luces
+Flag_8 = Paleta extra
+
+//Lang_Db_Frame
+4 = Frame
+
+//Lang_Db_Loop
+5 = Bucle
+
+//Lang_Db_AnimSpeed
+6 = Velocidad de animación
+
+//Lang_Db_AniImageset
+7 = Conjunto de imágenes
+
+
+
+[Mapshot]
+//Lang_Ms_AllocatingTemporarySurface
+1 = Asignando superficie temporal
+
+//Lang_Ms_AllocatingDestinationSurface
+2 = Asignando superficie de destino
+
+//Lang_Ms_PreparingMemory
+3 = Preparando memoria
+
+//Lang_Ms_Error
+4 = Error de Mapshot
+
+//Lang_Ms_NotEnoughMem
+5 = WapMap no pudo asignar suficiente memoria. Por favor seleccione una escala menor e intente nuevamente.
+
+//Lang_Ms_Drawing
+6 = Dibujando
+
+//Lang_Ms_Processing
+7 = Procesando
+
+//Lang_Ms_Chunk
+8 = Fragmento
+
+//Lang_Ms_Saving
+9 = Guardando
+
+//Lang_Ms_DrawObjects
+10 = Dibujar objetos
+
+//Lang_Ms_BackgroundColor
+11 = Color de fondo
+
+//Lang_Ms_CompressionLevel
+12 = Nivel de compresión
+
+//Lang_Ms_NoCompression
+13 = Sin compresión
+
+//Lang_Ms_DisclaimerJPG
+14 = JPG utiliza compresión con pérdida. Esto significa que a mayor compresión el archivo es más pequeño pero de peor calidad, aunque el proceso es rápido.
+
+//Lang_Ms_DisclaimerPNG
+15 = PNG utiliza compresión sin pérdida. Esto significa que a mayor compresión el archivo es más pequeño manteniendo la calidad, pero el proceso es más lento.
+
+//Lang_Ms_CompressionDefault
+16 = Predeterminado
+
+//Lang_Ms_CompressionLow
+17 = Bajo
+
+//Lang_Ms_CompressionMedium
+18 = Medio
+
+//Lang_Ms_CompressionHigh
+19 = Alto
+
+OpenFileDir = Abrir carpeta del archivo después de guardar
+
+[BrushMaker]
+//Lang_BM_BrushMaker
+1 = BrushMaker
+
+//Lang_MB_PleaseWait
+2 = Por favor espere...
+
+//Lang_BM_NoREZ
+3 = Debe seleccionar la ruta REZ por defecto.
+
+//Lang_BM_WrongREZ
+4 = El archivo REZ por defecto está dañado.
+
+//Lang_BM_PaletteFail
+5 = La paleta está dañada.
+
+//Lang_BM_Running
+6 = BrushMaker ya se está ejecutando.
+
+[Stats]
+WindowCaption = Estadísticas del mapa
+Tab_General = General
+Tab_Objects = Objetos
+
+Lab_Treasures = Tesoros
+
+Lab_Treasure1 = Monedas
+Lab_Treasure2 = Lingotes de oro
+Lab_Treasure3 = Anillos
+Lab_Treasure4 = Cáliz
+Lab_Treasure5 = Collares
+Lab_Treasure6 = Cruces
+Lab_Treasure7 = Cetros
+Lab_Treasure8 = Geckos
+Lab_Treasure9 = Coronas
+Lab_Treasure10 = Calaveras
+
+[Hints]
+FileSaved = Archivo guardado
+FileSavedAs = Archivo guardado como
+SelectedBrush = Pincel seleccionado
+SelectedTile = Tile seleccionado
+NothingToSave = No hay nada para guardar.
+FileOpened = Archivo abierto
+
+ActivePlaneChange = Plano activo cambiado
+
+TileClipboardOpen = Vista previa del portapapeles de tiles abierta.
+TileClipboardClose = Vista previa del portapapeles de tiles cerrada.
+ObjectClipboardOpen = Vista previa del portapapeles de objetos abierta.
+ObjectClipboardClose = Vista previa del portapapeles de objetos cerrada.
+
+ModeSwitchTile = Cambiado al modo tiles.
+ModeSwitchObject = Cambiado al modo objetos.
+ModeSwitchSim = Cambiado al modo simulación.
+
+ToolMeasure = Herramienta de medición seleccionada.
+ToolTilePencil = Herramienta lápiz seleccionada.
+ToolTileBrush = Herramienta pincel seleccionada.
+ToolTileFill = Herramienta de relleno seleccionada.
+
+
+[ClipboardPreview]
+TileClipboard = Vista previa del portapapeles de tiles
+ObjectClipboard = Vista previa del portapapeles de objetos
+TileClipboardEmpty = El portapapeles de tiles está vacío.
+ObjectClipboardEmpty = El portapapeles de objetos está vacío.
+
+[ObjectSearch]
+InputLabel = Ingrese el nombre completo (o parte del objeto)
+CaseSensitive = Sensible a mayúsculas
+NoResults = No se encontraron resultados.
+FoundResults = Resultados encontrados
+GoToObject = Seleccionar objeto
+SelectAll = Seleccionar todo
+ID = ID
+Name = Nombre
+Logic = Lógica
+ImageSet = Conjunto de imágenes
+Anim = Anim.
+Pos = Posición
+
+Term_0 = nombre
+Term_1 = lógica
+Term_2 = conjunto de imágenes
+Term_3 = animación
+
+[ObjProp]
+SelMinMaxVal = Seleccionar valores del rectángulo X, Y
+SelVals = Seleccionar valores
+PickX1 = Seleccionar X 1
+PickY1 = Seleccionar Y 1
+PickX2 = Seleccionar X 2
+PickY2 = Seleccionar Y 2
+PickByArea = Seleccionar por área
+Accept = Aceptar
+Movement = Movimiento
+
+[NewMap]
+NewMap = Nuevo mapa
+TargetGame = Juego destino
+Create = Crear
+Area = Área
+Claw_1 = La Roca
+Claw_2 = The Battlements
+Claw_3 = The Footpath
+Claw_4 = The Dark Woods
+Claw_5 = The Township
+Claw_6 = El Puerto del Lobo
+Claw_7 = The Docks
+Claw_8 = The Shipyards
+Claw_9 = Pirates' Cove
+Claw_10 = The Cliffs
+Claw_11 = The Caverns
+Claw_12 = The Undersea Caves
+Claw_13 = Tiger Island
+Claw_14 = The Temple
+Gruntz_1 = Rocky Roadz
+Gruntz_2 = Gruntziclez
+Gruntz_3 = Trouble in the Tropicz
+Gruntz_4 = High on Sweetz
+Gruntz_5 = High Rollerz
+Gruntz_6 = Honey, I shrunk the Gruntz!
+Gruntz_7 = The Miniature Masterz
+Gruntz_8 = Gruntz in Space
+MapName = Nombre del mapa
+MapAuthor = Autor del mapa
+AddBackFrontPlanes = Agregar plano de fondo / primer plano por defecto.
+MainPlaneSize = Tamaño del plano principal
+InvalidPlaneSize = El tamaño del plano principal no es válido. Debe ser al menos 50x50.
+NoName = Debe proporcionar el nombre del nivel.
+NoAuthor = Debe proporcionar el autor del nivel.
+NewDoc = Nuevo documento.wdd
+
+[FirstRun]
+Caption = Bienvenido a WapMap
+SetClawDir = Establecer ubicación de instalación de Claw
+JoinDiscord = Únete a nosotros
+Text = ~w~Gracias por descargar y usar ~g~WapMap~w~. Parece que lo estás ejecutando por primera vez. Todavía es una versión beta, lo que significa que algunas funciones pueden no estar aún implementadas o no funcionar correctamente, y podrías experimentar cierres ocasionales, así que por favor recuerda hacer copias de seguridad de tu trabajo.~n~~n~Asegúrate de visitar ~g~The Claw Recluse~w~ y el servidor de Discord de ~g~Claw Forum~w~ para obtener información adicional y soporte técnico.~n~~n~Como esta es tu primera ejecución, abre la configuración de WapMap y asegúrate de que el ~g~directorio de instalación del juego~w~ esté configurado correctamente.
+
+[MapProperties]
+NoName = El nombre del nivel no puede estar vacío.
+NoAuthor = El autor del nivel no puede estar vacío.
+NoRez = La ruta del REZ no puede estar vacía.
+NoTiles = La ruta de los tiles no puede estar vacía.
+NoPalette = La ruta de la paleta no puede estar vacía.
+NoExe = La ruta del ejecutable no puede estar vacía.
+TooLongName = El nombre del nivel es demasiado largo. Puede tener como máximo 64 caracteres.
+TooLongAuthor = El nombre del autor del nivel es demasiado largo. Puede tener como máximo 64 caracteres.
+TooLongRez = La ruta del REZ es demasiado larga. Puede tener como máximo 256 caracteres.
+TooLongTiles = La ruta de los tiles es demasiado larga. Puede tener como máximo 128 caracteres.
+TooLongPalette = La ruta de la paleta es demasiado larga. Puede tener como máximo 128 caracteres.
+TooLongExe = La ruta del ejecutable es demasiado larga. Puede tener como máximo 128 caracteres.
+
+[PlaneProperties]
+Caption = Propiedades del plano
+SelectPlane = Seleccionar plano:
+NewPlane = [Nuevo plano]
+Tileset = Conjunto de tiles:
+Size = Tamaño
+TileDim = Tamaño del tile [px]:
+Movement = Velocidad de movimiento [%]:
+ZCoord = Coordenada Z:
+Flags = Flags:
+FlagMainPlane = Plano principal
+FlagNoDraw = No dibujar
+FlagWrapX = Repetir en X
+FlagWrapY = Repetir en Y
+FlagAutoTileSize = Tamaño de tile automático
+Anchor = Anclaje
+Width = Ancho:
+Height = Alto:
+MainPlaneDelete = No puedes eliminar el plano principal. Para eliminar este plano marca un~ ~plano diferente con la opción "Plano principal".
+MainPlaneUncheck = No puedes desmarcar la opción "Plano principal". Para liberar este plano marca otro plano como "Plano principal".
+NoPlaneName = Debes ingresar un nombre para el plano.
+InvalidPlaneSize = El ancho y alto del plano no pueden ser cero o negativos.
+InvalidMoveMod = El porcentaje de movimiento no puede ser negativo.
+InvalidTileSize = El ancho y alto del tile no pueden ser cero o negativos.
+InvalidZCoord = La coordenada Z no puede ser negativa.
+PlaneNameTooLong = El nombre del plano es demasiado largo. Puede tener como máximo 64 caracteres.
+MainPlaneObjectsDrop = El plano actual marcado como "Plano principal" (%s) contiene %d objetos. Al cambiar el plano principal, esos objetos se perderán. ¿Desea continuar?
+StartPosMoved = El punto inicial estaba fuera del alcance de este plano. Fue movido de %d,%d a %d,%d.
+NameTaken = Ese nombre de plano ya está en uso.
+
+[Various]
+ContextAdv = Opciones del objeto
+ContextEdit = Editar
+ContextDraw = Dibujar
+ContextVer = Voltear verticalmente
+ContextHor = Voltear horizontalmente
+ContextNoDraw = Invisible
+MsgRecalcMinMaxXY = ¿Desea recalcular los rectángulos del objeto?
+ContextZCoord = Coordenada Z
+ContextZ_Increase3 = Aumentar (+1000)
+ContextZ_Increase2 = Aumentar (+100)
+ContextZ_Increase = Aumentar (+10)
+ContextZ_Decrease = Disminuir (-10)
+ContextZ_Decrease2 = Disminuir (-100)
+ContextZ_Decrease3 = Disminuir (-1000)
+ContextZ_Back = Enviar al fondo (1000)
+ContextZ_Action = Establecer acción (4000)
+ContextZ_Front = Traer al frente (5000)
+ContextAlign = Alinear objetos
+ContextAlign_Vert = En eje Y
+ContextAlign_Hor = En eje X
+ContextFlip = Espejar objetos
+ContextFlipX = Horizontalmente
+ContextFlipY = Verticalmente
+ContextSpace = Espaciar objetos
+ContextSpaceHor = Espaciado horizontal
+ContextSpaceVer = Espaciado vertical
+ContextTestFromHere = Probar desde aquí
+ContextFlags = Flags
+ContextEditLogic = Editar lógica
+
+AlignObj_Info = Seleccione el objeto al que desea alinear.
+
+MoveObj_Info1 = alinear al eje
+MoveObj_Info2 = alinear a la grilla
+MoveObj_Info3 = cancelar
+
+FileUnsavedPrompt = El archivo '%s' no está guardado. ¿Desea guardarlo ahora?
+UnableToSave = El archivo '%s' no pudo ser guardado.
+
+MinMaxRect = Rect. mín.-máx.
+
+BadNamePrompt = WapMap detectó que el archivo que desea cargar tiene un nombre inválido. ¿Desea corregirlo automáticamente ahora?
+
+TilesOnScreen = Tiles en pantalla:
+ObjectsOnScreen = Objetos en pantalla:
+WorldMousePosition = Coord. del mundo:
+TileMousePosition = Coord. del tile:
+Zoom = Zoom:
+
+Clear = Limpiar
+
+[ContextNewObj]
+Previous = Anterior
+Next = Siguiente
+Empty = Objeto vacío
+CrumblingPeg = Estaca frágil
+BreakPlank = Puente rompible
+TogglePeg = Estaca conmutada
+Elevator = Plataforma móvil
+PathElevator = Plataforma con recorrido
+SpringBoard = Trampolín
+Rope = Cuerda
+Treasure = Tesoro
+Health = Vida / munición
+Catnip = Poder especial
+Curse = Maldición multijugador
+Crate = Caja
+Statue = Estatua
+Enemy = Enemigo
+PowderKeg = Barril explosivo
+Cannon = Cañón automático
+Spikes = Pinchos / sierra
+Projectile = Disparador de proyectiles
+EyeCandy = Decoración
+Text = Texto
+Checkpoint = Punto de control
+Warp = Teletransporte
+Dialog = Disparador de sonido
+Sound = Sonido ambiental
+EndOfLevel = Fin de nivel
+CrabNest = Nido de cangrejos
+Stalactite = Estalactita
+Laser = Láser
+Shake = Efecto de sacudida
+
+[EditObj_Curse]
+WinCaption = Propiedades de la maldición
+CurseEffect = Efecto de la maldición
+Curse0 = Maldición de congelamiento
+Curse1 = Maldición del tesoro
+Curse2 = Maldición de salud
+Curse3 = Maldición de muerte
+Curse4 = Maldición de munición
+Curse5 = Maldición de magia
+CurseDesc0 = todos los jugadores quedarán congelados durante 5 segundos.
+CurseDesc1 = todos los jugadores perderán el 20% del puntaje.
+CurseDesc2 = todos los jugadores perderán el 50% de la salud.
+CurseDesc3 = todos los jugadores morirán.
+CurseDesc4 = todos los jugadores perderán su munición.
+CurseDesc5 = todos los jugadores perderán las garras mágicas.
+
+[EditObj_ElevPath]
+WinCaption = Propiedades del elevador por ruta
+Steps = Pasos
+Move = Mover
+Wait = Esperar
+ImgSet = Conjunto de imágenes
+Speed = Velocidad de movimiento (px/s)
+AddStep = Agregar
+DeleteStep = Eliminar
+Type = Acción
+Movement = Movimiento (px)
+WaitTime = Tiempo de espera (ms)
+Direction = Dirección
+GenerateChain = Generar ruta
+InvertChain = Invertir ruta
+InvertChainX = Invertir horizontal
+InvertChainY = Invertir vertical
+CloseChain = Cerrar ruta
+MsgDifferentEnd = La ruta del elevador termina en coordenadas diferentes a su origen. Esto provocará que el elevador salte a la posición inicial al final del recorrido. ¿Desea guardar los cambios de todos modos?
+MsgGenChainChangesMade = Los cambios realizados en el elevador deben guardarse antes de generar la ruta. ¿Desea guardar los cambios ahora y generar la ruta?
+MsgCloseChainStepCut = Para cerrar la ruta del elevador, los últimos pasos deben ser modificados. ¿Desea continuar?
+
+[EditObj_Checkpoint]
+WinCaption = Propiedades del punto de control
+Checkpoint = Punto de control normal
+SuperCheckpoint1 = Primer guardado del juego
+SuperCheckpoint2 = Segundo guardado del juego
+BossStager = Inicio de combate con jefe
+
+[EditObj_Warp]
+WinCaption = Propiedades del teletransporte
+Hor = Teletransporte horizontal
+Ver = Teletransporte vertical
+Boss = Teletransporte de jefe
+TeleportDestination = Destino
+Pick = Seleccionar
+Unpick = Cancelar
+SpawnPos = Posición de aparición
+OneTime = Teletransporte de un solo uso
+Context_GoTo = Ir al destino
+
+[EditObj_WallCannon]
+WinCaption = Propiedades del cañón
+Left = Izquierda
+Right = Derecha
+Direction = Dirección
+SpeedX = Velocidad X [px/s]
+SpeedY = Velocidad Y [px/s]
+LinSpeed = Velocidad lineal [px/s]
+Angle = Ángulo [grados]
+
+[EditObj_CrumblingPeg]
+WinCaption = Estaca frágil
+Imageset = Imagen
+NoRespawn = Sin reaparición
+
+[EditObj_Statue]
+WinCaption = Estatua
+
+[EditObj_Container]
+WarpDest = Destino del teletransporte
+Treasures = Tesoros:
+Durability = Durabilidad:
+Dur_1 = Un golpe
+Dur_2 = Dos golpes
+Dur_3 = Indestructible
+Randomize = Aleatorizar
+RandomItemCount = Cantidad aleatoria de ítems
+IncludeSpecials = Incluir poderes especiales
+Context_Randomize = Aleatorizar tesoros
+
+[EditObj_Shake]
+WinCaption = Propiedades del temblor
+ActivationArea = Área de activación
+
+[EditObj_Crate]
+WinCaption = Propiedades de la caja
+
+[EditObj_Inventory]
+WinCaption = Inventario
+Effect = Efecto
+ItemID = ID del ítem
+E_1  = +500 puntos
+
+E_2  = +1500 puntos
+E_3  = +1500 puntos
+E_4  = +1500 puntos
+E_5  = +1500 puntos
+
+E_6  = +2500 puntos
+
+E_7  = +5000 puntos
+E_8  = +5000 puntos
+E_9  = +5000 puntos
+E_10 = +5000 puntos
+
+E_11 = +7500 puntos
+E_12 = +7500 puntos
+E_13 = +7500 puntos
+E_14 = +7500 puntos
+
+E_15 = +10000 puntos
+E_16 = +10000 puntos
+E_17 = +10000 puntos
+E_18 = +10000 puntos
+
+E_19 = +25 munición
+E_20 = +5 munición
+E_21 = +10 munición
+
+E_22 = 15 segundos de catnip
+E_23 = 30 segundos de catnip
+
+E_24 = +5 salud
+E_25 = +25 salud
+E_26 = +10 salud
+E_27 = +15 salud
+
+E_28 = +5 garras mágicas
+E_29 = +10 garras mágicas
+E_30 = +35 garras mágicas
+
+E_31 = Fin del nivel
+E_32 = Teletransporta al jugador
+E_32B = Sin efecto (no funciona)
+
+E_33 = +100 puntos
+
+E_34 = +5 dinamita
+
+E_35 = Maldición de munición
+E_36 = Maldición de magia
+E_37 = Maldición de salud
+E_38 = Maldición de muerte
+E_39 = Maldición del tesoro
+E_40 = Maldición de congelamiento
+
+E_41 = +2500 puntos
+E_42 = +2500 puntos
+E_43 = +2500 puntos
+E_44 = +2500 puntos
+
+E_45 = +15000 puntos
+E_46 = +15000 puntos
+E_47 = +15000 puntos
+E_48 = +15000 puntos
+
+E_49 = +25000 puntos
+E_50 = +25000 puntos
+E_51 = +25000 puntos
+E_52 = +25000 puntos
+
+E_53 = Invisibilidad por 30 segundos
+E_54 = Invulnerabilidad por 30 segundos
+E_55 = Vida extra
+
+E_56 = Espada de fuego por 30 segundos
+E_57 = Espada de rayo por 30 segundos
+E_58 = Espada de hielo por 30 segundos
+
+[EditObj_BreakPlank]
+WinCaption = Tabla rompible
+Delay = Retardo [ms]
+Width = Ancho
+
+[EditObj_Treasure]
+WinCaption = Propiedades del tesoro
+AddGlitter = Agregar brillo
+
+[EditObj_Rope]
+WinCaption = Propiedades de la cuerda
+Animated = Animado
+Speed = Velocidad [ms]
+Delay = Desfase del ciclo [ms]
+
+[EditObj_Health]
+WinCaption = Propiedades del objeto recogible
+
+[EditObj_SpecialPowerup]
+WinCaption = Propiedades del objeto especial
+Time = Tiempo [ms]
+DontDisappear = No eliminar después de usar
+
+[EditObj_TogglePeg]
+WinCaption = Estaca conmutada
+TimeOn = Tiempo encendido [ms]
+TimeOff = Tiempo apagado [ms]
+Delay = Desfase del ciclo [ms]
+AlwaysOn = Siempre activo
+Win2Caption = Creación de serie
+IncrementValues = Incrementar valores en:
+
+[EditObj_Candy]
+WinCaption = Propiedades de la decoración
+Animated = Animado
+Tab_Standard = Estándar
+Tab_Custom = Personalizado
+Tab_Other = Otros
+HighDetail = Oculto en modo de bajo detalle
+NoImages = No hay imágenes en esta categoría.
+
+[EditObj_Laser]
+WinCaption = Propiedades del láser
+TimeOff = Tiempo apagado [ms]
+Damage = Daño [hp]
+
+[EditObj_SpringBoard]
+WinCaption = Propiedades del trampolín
+OverlayValue = Altura de salto
+JumpHeight = Altura de salto
+Pick = Seleccionar
+Cancel = Cancelar
+
+[EditObj_Dialog]
+WinCaption = Propiedades del disparador de sonido
+VerseStandard = Verso
+VerseOther = Otro
+Preview = Vista previa
+ShowExclamation = Mostrar signo de exclamación sobre la cabeza del jugador
+
+ActivationPolicy = Reproducir sonido cuando el jugador entre en el área:
+ActivationPolicy1 = Cada vez
+ActivationPolicy2 = Una vez por vida
+ActivationPolicy3 = Cantidad limitada de veces
+
+FR_Size = Área de activación:
+FirstRect1 = Pequeña (32x32)
+FirstRect2 = Chica (64x64)
+FirstRect3 = Estándar (128x128)
+FirstRect4 = Grande (256x256)
+FirstRect5 = Muy grande (512x512)
+FirstRect6 = Ancha (200x64)
+FirstRect7 = Alta (64x200)
+
+SR = Agregar segunda área
+TR = Agregar tercera área
+Pick = Seleccionar
+Cancel = Cancelar
+
+SoundRect_1 = Primera área
+SoundRect_2 = Segunda área
+SoundRect_3 = Tercera área
+
+[EditObj_Projectile]
+WinCaption = Propiedades del proyectil
+Speed = Velocidad de vuelo [px/s]
+Delay = Retardo de disparo [ms]
+Damage = Daño [hp]
+Direction = Dirección del disparo
+ActivationRect = Área de activación
+Pick = Seleccionar
+Cancel = Cancelar
+
+[EditObj_Stalactite]
+WinCaption = Propiedades de la estalactita
+ActivationArea = Área de activación
+
+[EditObj_CrabNest]
+WinCaption = Propiedades del nido
+CrabNum = Cantidad de cangrejos:
+ActivationArea = Área de activación
+
+[EditObj_Ambient]
+WinCaption = Propiedades del sonido ambiental
+Volume = Volumen [%]
+Preview = Vista previa
+AreaType = Alcance
+AreaGlobal = Global
+AreaSpecified = Especificada
+SpecifyArea = Especificar área
+SecondArea = Agregar segunda área
+PlayPolicy = Modo de reproducción
+PlayLoop = Repetir
+PlayInterval = Con intervalo
+TimeOn = Tiempo aleatorio activo [ms]
+TimeOff = Tiempo aleatorio inactivo [ms]
+TimeMin = Tiempo mínimo
+TimeMax = Tiempo máximo
+
+[Dialog_Translations]
+LEVEL_TRIGGER_1000 = ¡Mmm! ¡Se ve delicioso!
+LEVEL_TRIGGER_1004 = Hombre, esto será difícil.
+LEVEL_TRIGGER_1005 = Esto parece desafiante...
+LEVEL_TRIGGER_1006 = ¡Uf, eso estuvo cerca!
+LEVEL_TRIGGER_1007 = Tiene que haber una salida.
+LEVEL_TRIGGER_1040 = Ehh, esto es una molestia menor.
+LEVEL_TRIGGER_1052 = (Bostezo) Ejercicio inútil.
+LEVEL_TRIGGER_1053 = Pérdida de tiempo.
+LEVEL_TRIGGER_1060 = ¡No tengo todo el día para dar vueltas en círculos!
+LEVEL_TRIGGER_1045 = Ahh, esto requerirá una estrategia cuidadosa.
+LEVEL_TRIGGER_1013 = ¡Me estoy acercando, lo siento!
+LEVEL_TRIGGER_1032 = Debo estar soñando despierto.
+LEVEL_TRIGGER_1044 = Tendré que abrirme camino a la fuerza.
+LEVEL_TRIGGER_1011 = ¡Nunca me atraparán!
+LEVEL_TRIGGER_1012 = ¿No hay fin en este bosque?
+LEVEL_TRIGGER_1034 = Mis ojos me engañan.
+LEVEL_TRIGGER_1110014 = ¡Ooh, ese oro que huelo!
+LEVEL_TRIGGER_1110017 = Este camino no está en el mapa.
+LEVEL_TRIGGER_DEADEND = Callejón sin salida.
+LEVEL_TRIGGER_DEATHTRAP = Qué trampa mortal.
+LEVEL_TRIGGER_LOST = Ehh, ¿cómo salgo de aquí?
+LEVEL_TRIGGER_ONESHOT = Solo tengo una oportunidad para esto.
+LEVEL_TRIGGER_PATHNOTONMAP = Este camino no está en el mapa.
+LEVEL_TRIGGER_SMELLGOLD = ¡Ooh, ese oro que huelo!
+LEVEL_TRIGGER_SOFARSOGOOD = Hasta ahora, todo bien.
+LEVEL_TRIGGER_1061 = No necesito más ejercicio.
+LEVEL_TRIGGER_TIMING = ¡Esto requerirá un tiempo perfecto!
+LEVEL_TRIGGER_1110020 = ¡Malditas aves!
+LEVEL_TRIGGER_1010 = ¡Nunca me atraparán!
+LEVEL_TRIGGER_1049 = Me pregunto cuántos años tendrán estas estatuas. Bueno.
+LEVEL_TRIGGER_1062 = No este gato, Jack.
+LEVEL_TRIGGER_1015 = ¡Puaj! Qué olor putrefacto.
+LEVEL_TRIGGER_1016 = ¡Algo apesta!
+LEVEL_TRIGGER_1017 = ¡Ooh! Qué maravilla de ingeniería.
+LEVEL_TRIGGER_BLOODYBIRDS = ¡Malditas aves!
+LEVEL_TRIGGER_1043 = Finalmente, un oponente digno.
+LEVEL_TRIGGER_1001 = Mhm, suena delicioso.
+LEVEL_TRIGGER_1002 = No hay tiempo para comer ahora.
+LEVEL_TRIGGER_1110015 = Solo tengo una oportunidad para esto.
+LEVEL_TRIGGER_1110016 = Hasta ahora, todo bien.
+LEVEL_TRIGGER_1003 = No parece fresco
+LEVEL_TRIGGER_1051 = No creo que eso le ayude.
+LEVEL_TRIGGER_1054 = ¡No pierdas mi tiempo!
+LEVEL_TRIGGER_1018 = ¿Dónde está su barco?
+LEVEL_TRIGGER_1019 = ¡Grrr! ¡Puedo olerte Red Tail!
+LEVEL_TRIGGER_1020 = Ahh, los hombres de Red Tail. Debo estar cerca.
+LEVEL_TRIGGER_1021 = ¿Dónde está ese bribón?
+LEVEL_TRIGGER_1026 = Ahh, piratas novatos.
+LEVEL_TRIGGER_1110018 = Qué trampa mortal.
+LEVEL_TRIGGER_1027 = ¿No saben quién soy?
+LEVEL_TRIGGER_1028 = Muestra algo de respeto, ¿quieres?
+LEVEL_TRIGGER_1110019 = Callejón sin salida.
+LEVEL_TRIGGER_1110010 = ¡OOOooooOOOOooo!
+LEVEL_TRIGGER_1110011 = Esto requerirá un tiempo perfecto.
+LEVEL_TRIGGER_1110013 = Ehh, ¿cómo salgo de aquí?
+LEVEL_TRIGGER_1022 = Eeh, esto me resulta familiar.
+LEVEL_TRIGGER_1023 = ¡Cobardes!
+LEVEL_TRIGGER_1024 = Aah, estos no son piratas de verdad.
+LEVEL_TRIGGER_1025 = ¡Piratas impostores!
+LEVEL_TRIGGER_1110017 = Este camino no está en el mapa.
+LEVEL_TRIGGER_1029 = ¿Dónde está mi tripulación?
+LEVEL_TRIGGER_TARZAN = ¡OOOooooOOOOooo!
+LEVEL_TRIGGER_PATHONMAP = Este camino no está en el mapa.
+LEVEL_TRIGGER_1030 = Ugh, ¿qué son estas criaturas?
+LEVEL_TRIGGER_1031 = ¿Qué diablos es esto?
+LEVEL_TRIGGER_1014 = Wow, nunca había visto algo así antes.
+LEVEL_TRIGGER_1033 = Hm, ahora.
+LEVEL_TRIGGER_1054 = ¡No pierdas mi tiempo!
+LEVEL_TRIGGER_1038 = Esto no parece sabroso.
+LEVEL_TRIGGER_1050 = Esto debe ser alguien importante.
+LEVEL_TRIGGER_1035 = ¡Ooh, qué lugar tan extraño!
+LEVEL_TRIGGER_1047 = ¡Sé que Red Tail tiene algunas gemas!
+LEVEL_TRIGGER_1048 = ¡Solo queda una gema!
+CLAW_1110001 = ¡Sí! ¡Espada de fuego!
+CLAW_1110012 = ¡Ja! ¡Espada de hielo!
+CLAW_1110022 = ¡Ja! ¡Espada de relámpago!
+CLAW_1110033 = ¡Ja!
+CLAW_1110035 = ¡Hola!
+CLAW_1110037 = ¡No me estoy haciendo más joven!
+CLAW_1110038 = ¡Al menos tráeme algo de la cocina!
+CLAW_1110043 = ¡Estoy impaciente!
+CLAW_1110045 = ¡Estoy esperando!
+CLAW_1110056 = ¡Las gemas no se encontrarán solas!
+CLAW_1110057 = ¡El amuleto espera!
+CLAW_1110058 = ¡Touche!
+CLAW_1110059 = ¡Débil!
+CLAW_1110063 = ¡SÍ! (largo)
+CLAW_1110064 = ¡SÍ! (corto)
+CLAW_1001 = ¡Ja, toma eso!
+CLAW_1002 = ¡Garra mágica!
+CLAW_1003 = ¡Trágate esto!
+CLAW_1004A = ¡Pícaro!
+CLAW_1004B = ¡Pícaro! (fuerte)
+CLAW_1007A = ¡Terrícola! (corto)
+CLAW_1007B = ¡Terrícola! (largo)
+CLAW_1009 = ¡Mastica esto! (corto)
+CLAW_1010 = ¡Mastica eso! (largo)
+CLAW_1021 = ¡Woooow!
+CLAW_1054 = ¡No pierdas mi tiempo!
+GAME_1055 = Espejito, espejito en la pared… ¿quién es el gato más guapo de todos?
+CLAW_1055 = Espejito, espejito en la pared… ¿quién es el gato más guapo de todos?
+CLAW_1056 = ¡Hola! ¡Estoy en medio de una aventura!
+CLAW_1057 = ¡No tengo todo el día!
+CLAW_1058 = ¡Disculpa! ¡Tengo a dónde ir!
+CLAW_1062 = No este gato, Jack.
+
+[WinAuthors]
+Func_1 = Software diseñado y desarrollado por
+Func_2 = Utiliza la ecuación de checksum WWD calculada por
+Func_3 = Agradecimientos especiales por las pruebas y el apoyo de toda la comunidad de Claw
+
+[WinSpacing]
+WinCaption = Espaciado de objetos
+Distance = Distancia [px]
+
+[WinAddObjBatch]
+AddNext = Agregar siguiente
+
+[HomeScreen]
+Welcome = Bienvenido,
+WhatAreWeDoing = ¿qué vamos a hacer hoy?
+New = Crear nuevo documento
+Open = Abrir documento existente
+Changelog = Ver novedades de esta versión
+RecentDocs = Documentos usados recientemente:
+
+[Tool_ObjectBrush]
+UpdateRects = Actualizar rectángulos de objetos si corresponde
+ScatterX = Dispersión en X
+ScatterY = Dispersión en Y
+ScatterSeparately = Aplicar dispersión por separado a cada objeto
+
+[WinCrashRetrieve]
+WinCaption = Recuperar pestañas perdidas
+Label = WapMap no se cerró correctamente la última vez. ¿Desea recuperar las pestañas abiertas?
+Retrieve = Recuperar
+MoreTabs = ...y %d pestañas más.
+
+[MDI]
+Context_CloseAllExceptActive = Cerrar todas excepto la activa
+Context_CloseAll = Cerrar todas
+Context_PreviouslyClosed = Cerradas recientemente
+Context_Reload = Recargar
+ReloadError = No se pudo recargar el mapa %s.
+
+[EditObj_Elevator]
+WinCaption = Propiedades del elevador
+Type = Tipo:
+Standard_TT = Se mueve siempre.
+Start_TT = Se mueve solo cuando el jugador está encima.
+Stop_TT = Se mueve solo cuando el jugador NO está encima.
+Trigger_TT = Comienza a moverse cuando el jugador salta sobre él.
+OneWay = Una sola dirección
+OneWayDesc = Se detiene en el destino.
+MoveArea = Área de movimiento:
+Automatic = Automático
+Manual = Manual
+Distance = Distancia de recorrido (px):
+Speed = Velocidad (px/s):
+SpeedWarning = Una velocidad menor a 60 para este tipo de elevador~n~puede no funcionar correctamente y, por lo tanto,~n~no se recomienda.
+Horizontal = Horizontal:
+Vertical = Vertical:
+LockAspect_TT = Bloquear proporción.
+Direction = Dirección:
+Pick = Seleccionar
+
+[EditObj_Enemy]
+WinCaption = Propiedades del enemigo
+Type = Tipo:
+
+Logic_Officer = Officer
+Logic_Soldier = Soldier
+Logic_Rat = Rat
+Logic_PunkRat = Rat on cannon
+Logic_Raux = La Rauxe [boss]
+Logic_RobberThief = Robber thief
+Logic_CutThroat = Cutthroat
+Logic_Katherine = Katherine [boss]
+Logic_TownGuard1 = Guard #1
+Logic_TownGuard2 = Guard #2
+Logic_Wolvington = Wolvington [boss]
+Logic_PegLeg = Peg leg
+Logic_CrazyHook = Crazy hook
+Logic_Marrow = Marrow [boss]
+Logic_Mercat = Mercat
+Logic_Siren = Siren
+Logic_Fish = Fish
+Logic_Aquatis = Aquatis [boss]
+Logic_RedTail = Red Tail [boss]
+Logic_RedTailPirate = Pirate
+Logic_BearSailor = Bear
+Logic_HermitCrab = Crab
+Logic_HermitCrab2 = Bomber crab
+Logic_Seagull = Seagull
+Logic_Gabriel = Gabriel [boss]
+Logic_TigerGuard = Tiger
+Logic_TigerGuard2 = White Tiger
+Logic_Chameleon = Chameleon
+Logic_Omar = Omar [boss]
+
+Behaviour = Comportamiento:
+Behaviour_1 = Normal
+Behaviour_2 = Inmortal
+Behaviour_3 = Inmortal y sin causar daño
+Behaviour_4 = Congelar después de recibir daño
+Patrol = Área de patrulla
+
+Treasures = Tesoros:
+MoveArea = Área de movimiento:
+Clear = Limpiar
+Damage = Daño
+WarpDest = Destino del teletransporte:
+GemDest = Coordenadas de la gema:
+Pick = Seleccionar
+Cancel = Cancelar
+
+[WinObjectProperties]
+PickIS_WinCaption = Seleccionar imagen
+PickIS_ImageSet = Conjunto de imágenes:
+PickIS_Frame = Imagen:
+
+[EditObj_Text]
+WinCaption = Propiedades del texto
+Align = Alineación del texto:
+Apply = Actualizar
+Sample = Texto de ejemplo.
+
+[EditObj_FloorSpike]
+WinCaption = Propiedades de pincho / sierra
+TimeOn = Tiempo encendido [ms]
+TimeOff = Tiempo apagado [ms]
+Delay = Desfase del ciclo [ms]
+Damage = Daño
+Win2Caption = Creación de serie
+IncrementValues = Incrementar valores en:
+
+[AppMenu]
+Main_File = Archivo
+Main_Mode = Modo
+Main_Edit = Editar
+Main_Planes = Planos
+Main_View = Vista
+Main_Tools = Herramientas
+Main_WapMap = WapMap
+Main_Assets = Recursos
+
+File_New = Nuevo documento
+File_Open = Abrir...
+File_Recent = Abrir recientes
+File_Save = Guardar
+File_SaveAs = Guardar como...
+File_Export = Exportar a...
+File_Close = Cerrar
+File_CloseAll = Cerrar todo
+File_Exit = Salir
+
+Edit_World = Propiedades del mapa
+Edit_Planes = Administrar planos
+Edit_TileProp = Propiedades de tile
+Edit_GlobalScript = Script global
+
+PlaneDraw_Border = Dibujar borde
+PlaneDraw_Grid = Dibujar cuadrícula
+PlaneDraw_Objects = Dibujar objetos
+
+About_Settings = Configuración
+About_About = Acerca de
+About_Update = Buscar actualizaciones
+About_Readme = Manual
+About_Website = Sitio de Reclavation
+
+View_Rulers = Mostrar reglas
+View_PlaneVisibility = Visibilidad de planos
+View_TileProp = Mostrar máscaras de colisión de tiles
+View_GuideLines = Mostrar guías
+
+Tools_Mapshot = Mapshot
+Tools_Stats = Estadísticas
+Tools_Measure = Medir
+Tools_Play = Ejecutar juego
+Tools_Visibility = Opciones de visibilidad
+Tools_Camera = Cámara
+
+Assets_Tiles = Conjuntos de tiles
+Assets_ImgSets = Conjuntos de imágenes
+Assets_Anims = Animaciones
+Assets_Logics = Lógicas
+Assets_Sounds = Sonidos
+Assets_Palettes = Paletas
+Assets_New = Agregar nuevos recursos
+
+[TilePicker]
+WinCaption = Selector de tiles
+ModePencil = Lápiz
+ModeBrush = Pincel
+ReloadBrushes = Recargar pinceles
+ShowTileID = Mostrar ID de tiles
+ShowTileProp = Mostrar máscaras de colisión de tiles
+LineThickness = Grosor de línea
+PointSize = Tamaño del punto
+SpraySize = Tamaño del spray
+SprayDensity = Densidad del spray
+ToolOptions = Opciones de herramienta:
+Filled = Relleno
+
+[Options]
+GameInstallDir = Directorio de instalación del juego:
+Editor = Configuración del editor
+CrazyHook = Configuración de CrazyHook:
+CrazyHookNotFound = CrazyHook no fue detectado.
+GameRes = Resolución de pantalla
+DebugInf = Mostrar información de depuración
+GodMode = Iniciar con modo dios activado
+ArmorMode = Desactivar tiles mortales
+DetectedVer = Versión detectada:
+Default = Predeterminado
+
+[Win_AddAssets]
+WinCaption = Agregar nuevos recursos
+PlainType_Tiles = Tiles
+PlainType_ImgSets = Conjuntos de imágenes
+PlainType_Anims = Animaciones
+PlainType_Sounds = Sonidos
+PlainType_Logics = Lógicas
+
+[ObjectProperties]
+FrameI = Fotograma inicial:
+Default = Predeterminado
+LogicType = Tipo de lógica:
+LogicStandard = Estándar
+LogicCustom = Personalizada
+CustomLogicNameNotify = No se puede usar con lógica personalizada.
+CustomLogicEdit = Abrir archivo que contiene el código de la lógica personalizada.
+NoLogicStandard = No existe esa lógica en el conjunto estándar. Tu objeto no funcionará en el juego. ¿Seguro que deseas continuar?
+NoLogicCustom = No existe esa lógica en el conjunto personalizado. ¿Deseas crear esa lógica ahora?
+
+[Win_LogicBrowser]
+WinCaption = Navegador de lógicas
+SelectCustomLogic = Seleccionar lógica personalizada:
+DeleteWarning = ¿Seguro que deseas eliminar esta lógica? El archivo '%s' también será eliminado.
+LogicName = Nombre de la lógica:
+FilePath = Ruta del archivo:
+FileSize = Tamaño del archivo:
+FileChecksum = Checksum del archivo:
+ModDate = Fecha de modificación:
+AddNew = Agregar nueva lógica
+BrowseDir = Examinar directorio
+Edit = Editar código
+OpenFile = Abrir externamente
+Rename = Renombrar
+Delete = Eliminar
+NoGlobalScript = Este mapa no tiene script global. ¿Deseas crearlo ahora?
+GlobalScriptDocumentSave = Para editar el script global primero debes guardar tu mapa en disco.
+NewLogicDocumentSave = Para crear una nueva lógica primero debes guardar tu mapa en disco.
+RenamePrompt = ¿Deseas actualizar los objetos que usan esta lógica con el nuevo nombre?
+DialogInputName = Ingresa el nombre de la lógica:
+DialogInputNameErrorEmpty = El nombre de la lógica no puede estar vacío.
+DialogInputNameErrorExists = Este nombre de lógica ya está en uso o está reservado.
+
+[Win_TileBrowser]
+WinCaption = Navegador de tiles
+Tilesets = Conjuntos de tiles cargados:
+ImportTileset = Agregar conjunto de tiles personalizado
+TilesetName = Nombre del conjunto:
+TileCount = Cantidad de tiles:
+TilesetChecksum = Checksum del conjunto:
+TileID = ID del tile:
+TileChecksum = Checksum:
+TileModDate = Fecha de modificación:
+TileOrigin = Origen del archivo:
+tiles = tiles
+RenameTileset = Renombrar conjunto de tiles
+BrowseDirectory = Examinar directorio
+DeleteTileset = Eliminar conjunto de tiles
+ChangeID = Cambiar ID
+DeleteTile = Eliminar tile
+ImageDetails = Detalles de la imagen
+OriginREZ = Archivo REZ
+OriginClaw = Directorio de Claw (/Assets)
+OriginCustom = Directorio personalizado
+GroupREZ = tiles de archivo REZ
+GroupClaw = tiles del directorio del juego
+GroupCustom = tiles personalizados
+AddTiles = Agregar tiles personalizados
+
+[Win_PaletteBrowser]
+WinCaption = Navegador de paletas
+
+[Win_ImageSetBrowser]
+WinCaption = Navegador de conjuntos de imágenes
+ImageSets = Conjuntos de imágenes cargados:
+ImportImageSet = Agregar conjunto de imágenes personalizado
+ImageSetName = Nombre del conjunto:
+FrameCount = Cantidad de imágenes:
+ImageSetChecksum = Checksum del conjunto de imágenes:
+AddFrames = Agregar imágenes personalizadas
+FrameID = ID de la imagen:
+FrameChecksum = Checksum:
+FrameModDate = Fecha de modificación:
+FrameOrigin = Origen del archivo:
+FrameFileName = Nombre del archivo:
+FrameFilePath = Ruta del archivo:
+FrameDim = Dimensiones:
+frames = imágenes
+RenameImageSet = Renombrar conjunto de imágenes
+BrowseDirectory = Examinar directorio
+DeleteImageSet = Eliminar conjunto de imágenes
+ChangeID = Cambiar ID
+DeleteFrame = Eliminar imagen
+ImageDetails = Detalles de la imagen
+OriginREZ = Archivo REZ
+OriginClaw = Directorio de Claw (/Assets)
+OriginCustom = Directorio personalizado
+GroupREZ = Imágenes de archivo REZ
+GroupClaw = Imágenes del directorio del juego
+GroupCustom = Imágenes personalizadas
+
+[Win_ImageImport]
+WinCaption = Importar tile
+WinCaption2 = Importar conjunto de imágenes
+TilesetName = Nombre del conjunto de tile:
+ImagesetName = Nombre del conjunto de imágenes:
+WarnSpecifyTileset = Debes especificar el nombre del conjunto de tiles.
+WarnSpecifyImageset = Debes especificar el nombre del conjunto de imágenes.
+FilesToImport = Archivos a importar:
+SupportedTypes = Tipos de imagen soportados: gif, jpg, png, bmp, pcx, pid.
+TruecolorNote = Las imágenes a color verdadero se convertirán a la paleta del nivel.
+SelectFiles = Seleccionar archivos
+AutoID = Generar IDs
+Save = Importar
+Cancel = Cancelar
+NameUsed = Este nombre ya está en uso.
+
+WarnSpecifyID = Debes especificar el ID.
+WarnMultipleID = No puedes agregar múltiples archivos con el mismo ID.
+WarnUsedByCustomTile = Este ID ya está usado por otro tile personalizado.
+WarnUsedByCustomImage = Este ID ya está usado por otra imagen personalizada.
+InfoTileReplace = Este tile reemplazará el tile original con el mismo ID.
+InfoImageReplace = Esta imagen reemplazará la imagen original con el mismo ID.
+
+NoFiles = No hay archivos para agregar.
+DragDropHint = También puedes arrastrar y soltar archivos aquí.
+
+TileID = ID del tile:
+ImageID = ID de la imagen:
+ResultName = Nombre resultante:
+
+[Z_Coord]
+Label = Colocación (valor Z):
+Behind = Detrás
+Front = Delante
+Custom = Personalizado:


### PR DESCRIPTION
Adds a Spanish translation for the WapMap interface, including special characters like `¿`, `á`, `é`, `í`, `ó`, and `ñ`.

**Important details:**
- Translation is in UTF-8 format.
- Tested on v0.5.0 (b39).
- Some text may appear incorrectly due to system encoding or language settings. The project currently uses different encodings for different languages (English → UTF-8, Polski → Windows-1252, Russian → Windows-1252). To ensure correct display of Spanish special characters, save all source and interface files in UTF-8, update project/IDE/build encoding settings if necessary, ensure locale settings support Spanish characters, and verify font rendering if issues persist. As an alternative, replace special Spanish characters as follows: `¿` → ` `, `á` → `a`, `é` → `e`, `í` → `i`, `ó` → `o`, `ñ` → `nn`.
- This PR only modifies ini text file and does not change program functionality.